### PR TITLE
Lagt in funktionalitet för pipes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4617,9 +4617,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "prettier": {
     "trailingComma": "all",
-    "printWidth": 100
+    "printWidth": 200
   }
 }

--- a/src/hacking/ch07/MaybeUnion.test.ts
+++ b/src/hacking/ch07/MaybeUnion.test.ts
@@ -1,4 +1,14 @@
-import { Maybe, Just, None, orElse, flatMap, map, toString } from "./MaybeUnion";
+import {
+  Maybe,
+  None,
+  orElse,
+  flatMap,
+  toString,
+  filterFn,
+  mapFn,
+  pipe,
+  flatMapFn,
+} from "./MaybeUnion";
 
 function assertIsJust<T>(expectedValue: T, maybeT: Maybe<T>) {
   expect(maybeT).toHaveProperty("value", expectedValue);
@@ -24,14 +34,14 @@ describe("flatMap", () => {
   it("maps Just+Just to Just", () => {
     assertIsJust(
       "12",
-      flatMap(Maybe(1), n => Maybe(n + "2")),
+      flatMap(Maybe(1), (n) => Maybe(n + "2")),
     );
   });
   it("maps Just+None to None", () => {
-    assertIsNone(flatMap(Maybe(1), n => Maybe(null)));
+    assertIsNone(flatMap(Maybe(1), (n) => Maybe(null)));
   });
   it("maps None+Just to None", () => {
-    assertIsNone(flatMap(Maybe(null), n => Maybe(1)));
+    assertIsNone(flatMap(Maybe(null), (n) => Maybe(1)));
   });
 });
 
@@ -52,5 +62,31 @@ describe("toString", () => {
     it("should toString " + toStringed, () => {
       expect(toString(m)).toBe(toStringed);
     });
+  });
+});
+
+describe("pipe", () => {
+  it("can construct Just", () => {
+    const just1 = Maybe("Pelle");
+    const pipe1 = pipe(
+      just1,
+      mapFn((s) => s + " Svanslös"),
+      flatMapFn((s) => Maybe(s)),
+      mapFn((s) => s.length),
+      filterFn((l) => l > 10),
+    );
+    assertIsJust(14, pipe1);
+  });
+
+  it("can pipe None", () => {
+    const just1 = Maybe("Pelle");
+    const pipe1 = pipe(
+      just1,
+      filterFn((s) => s.startsWith("Q")),
+      mapFn((s) => s + " Svanslös"),
+      mapFn((s) => s.length),
+      filterFn((l) => l > 10),
+    );
+    assertIsNone(pipe1);
   });
 });

--- a/src/hacking/ch07/MaybeUnion.ts
+++ b/src/hacking/ch07/MaybeUnion.ts
@@ -8,36 +8,10 @@ type PipeFn<A, B> = (arg: Maybe<A>) => Maybe<B>;
 export function pipe<T>(value: Maybe<T>): Maybe<T>;
 export function pipe<T, A>(value: Maybe<T>, op1: PipeFn<T, A>): Maybe<A>;
 export function pipe<T, A, B>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>): Maybe<B>;
-export function pipe<T, A, B, C>(
-  value: Maybe<T>,
-  op1: PipeFn<T, A>,
-  op2: PipeFn<A, B>,
-  op3: PipeFn<B, C>,
-): Maybe<C>;
-export function pipe<T, A, B, C, D>(
-  value: Maybe<T>,
-  op1: PipeFn<T, A>,
-  op2: PipeFn<A, B>,
-  op3: PipeFn<B, C>,
-  op4: PipeFn<C, D>,
-): Maybe<D>;
-export function pipe<T, A, B, C, D, E>(
-  value: Maybe<T>,
-  op1: PipeFn<T, A>,
-  op2: PipeFn<A, B>,
-  op3: PipeFn<B, C>,
-  op4: PipeFn<C, D>,
-  op5: PipeFn<D, E>,
-): Maybe<E>;
-export function pipe<T, A, B, C, D, E, F>(
-  value: Maybe<T>,
-  op1: PipeFn<T, A>,
-  op2: PipeFn<A, B>,
-  op3: PipeFn<B, C>,
-  op4: PipeFn<C, D>,
-  op5: PipeFn<D, E>,
-  op6: PipeFn<E, F>,
-): Maybe<F>;
+export function pipe<T, A, B, C>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>): Maybe<C>;
+export function pipe<T, A, B, C, D>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>): Maybe<D>;
+export function pipe<T, A, B, C, D, E>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>, op5: PipeFn<D, E>): Maybe<E>;
+export function pipe<T, A, B, C, D, E, F>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>, op5: PipeFn<D, E>, op6: PipeFn<E, F>): Maybe<F>;
 export function pipe<T, A, B, C, D, E, F>(
   value: Maybe<T>,
   op1: PipeFn<T, A>,

--- a/src/hacking/ch07/MaybeUnion.ts
+++ b/src/hacking/ch07/MaybeUnion.ts
@@ -5,25 +5,25 @@ export type Maybe<T> = None | Just<T>;
 
 type PipeFn<A, B> = (arg: Maybe<A>) => Maybe<B>;
 
-export function pipe<T>(value: Maybe<T>): Maybe<T>;
-export function pipe<T, A>(value: Maybe<T>, op1: PipeFn<T, A>): Maybe<A>;
-export function pipe<T, A, B>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>): Maybe<B>;
-export function pipe<T, A, B, C>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>): Maybe<C>;
-export function pipe<T, A, B, C, D>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>): Maybe<D>;
-export function pipe<T, A, B, C, D, E>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>, op5: PipeFn<D, E>): Maybe<E>;
-export function pipe<T, A, B, C, D, E, F>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>, op5: PipeFn<D, E>, op6: PipeFn<E, F>): Maybe<F>;
+export function pipe<T>(m: Maybe<T>): Maybe<T>;
+export function pipe<T, A>(m: Maybe<T>, op1: PipeFn<T, A>): Maybe<A>;
+export function pipe<T, A, B>(m: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>): Maybe<B>;
+export function pipe<T, A, B, C>(m: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>): Maybe<C>;
+export function pipe<T, A, B, C, D>(m: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>): Maybe<D>;
+export function pipe<T, A, B, C, D, E>(m: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>, op5: PipeFn<D, E>): Maybe<E>;
+export function pipe<T, A, B, C, D, E, F>(m: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>, op3: PipeFn<B, C>, op4: PipeFn<C, D>, op5: PipeFn<D, E>, op6: PipeFn<E, F>): Maybe<F>;
 export function pipe<T, A, B, C, D, E, F>(
-  value: Maybe<T>,
+  m: Maybe<T>,
   op1: PipeFn<T, A>,
   op2: PipeFn<A, B>,
   op3: PipeFn<B, C>,
   op4: PipeFn<C, D>,
   op5: PipeFn<D, E>,
   op6: PipeFn<E, F>,
-  ...operations: PipeFn<any, any>[]
+  ...ops: PipeFn<any, any>[]
 ): Maybe<{}>;
-export function pipe<T>(value: Maybe<T>, ...operations: PipeFn<any, any>[]): Maybe<any> {
-  return operations.reduce((prev: Maybe<any>, fn: PipeFn<any, any>) => fn(prev), value);
+export function pipe<T>(m: Maybe<T>, ...ops: PipeFn<any, any>[]): Maybe<any> {
+  return ops.reduce((prev: Maybe<any>, fn: PipeFn<any, any>) => fn(prev), m);
 }
 
 function isNone(v: any): v is None {

--- a/src/hacking/ch07/MaybeUnion.ts
+++ b/src/hacking/ch07/MaybeUnion.ts
@@ -3,6 +3,55 @@ export type None = typeof None;
 export type Just<T> = { readonly value: T };
 export type Maybe<T> = None | Just<T>;
 
+type PipeFn<A, B> = (arg: Maybe<A>) => Maybe<B>;
+
+export function pipe<T>(value: Maybe<T>): Maybe<T>;
+export function pipe<T, A>(value: Maybe<T>, op1: PipeFn<T, A>): Maybe<A>;
+export function pipe<T, A, B>(value: Maybe<T>, op1: PipeFn<T, A>, op2: PipeFn<A, B>): Maybe<B>;
+export function pipe<T, A, B, C>(
+  value: Maybe<T>,
+  op1: PipeFn<T, A>,
+  op2: PipeFn<A, B>,
+  op3: PipeFn<B, C>,
+): Maybe<C>;
+export function pipe<T, A, B, C, D>(
+  value: Maybe<T>,
+  op1: PipeFn<T, A>,
+  op2: PipeFn<A, B>,
+  op3: PipeFn<B, C>,
+  op4: PipeFn<C, D>,
+): Maybe<D>;
+export function pipe<T, A, B, C, D, E>(
+  value: Maybe<T>,
+  op1: PipeFn<T, A>,
+  op2: PipeFn<A, B>,
+  op3: PipeFn<B, C>,
+  op4: PipeFn<C, D>,
+  op5: PipeFn<D, E>,
+): Maybe<E>;
+export function pipe<T, A, B, C, D, E, F>(
+  value: Maybe<T>,
+  op1: PipeFn<T, A>,
+  op2: PipeFn<A, B>,
+  op3: PipeFn<B, C>,
+  op4: PipeFn<C, D>,
+  op5: PipeFn<D, E>,
+  op6: PipeFn<E, F>,
+): Maybe<F>;
+export function pipe<T, A, B, C, D, E, F>(
+  value: Maybe<T>,
+  op1: PipeFn<T, A>,
+  op2: PipeFn<A, B>,
+  op3: PipeFn<B, C>,
+  op4: PipeFn<C, D>,
+  op5: PipeFn<D, E>,
+  op6: PipeFn<E, F>,
+  ...operations: PipeFn<any, any>[]
+): Maybe<{}>;
+export function pipe<T>(value: Maybe<T>, ...operations: PipeFn<any, any>[]): Maybe<any> {
+  return operations.reduce((prev: Maybe<any>, fn: PipeFn<any, any>) => fn(prev), value);
+}
+
 function isNone(v: any): v is None {
   return v === None;
 }
@@ -20,12 +69,28 @@ export function flatMap<T, V>(m: Maybe<T>, f: (t: T) => Maybe<V>): Maybe<V> {
 }
 
 export function map<T, V>(m: Maybe<T>, f: (t: T) => V): Maybe<V> {
-  return flatMap(m, t => Maybe(f(t)));
+  return flatMap(m, (t) => Maybe(f(t)));
+}
+
+export function filter<T>(m: Maybe<T>, f: (t: T) => boolean): Maybe<T> {
+  return isNone(m) || !f(m.value) ? None : m;
+}
+
+export function flatMapFn<T, V>(f: (t: T) => Maybe<V>): PipeFn<T, V> {
+  return (m: Maybe<T>) => flatMap(m, f);
+}
+
+export function mapFn<T, V>(f: (t: T) => V): PipeFn<T, V> {
+  return (m: Maybe<T>) => map(m, f);
+}
+
+export function filterFn<T>(f: (t: T) => boolean): PipeFn<T, T> {
+  return (m: Maybe<T>) => filter(m, f);
 }
 
 export function toString<T>(m: Maybe<T>): string {
   return orElse(
-    map(m, t => "Just(" + t + ")"),
+    map(m, (t) => "Just(" + t + ")"),
     "None",
   );
 }


### PR DESCRIPTION
Tjenare.
Utökade din kod med funktionalitet för pipes. Det blev lite klurigare än vad jag hade tänkt. Själva pipe-funktionen inspirerades kraftigt från rxjs, men det jag inte hade tänkt på var att själva operatorerna som ligger i pipen måste vara funktioner som returnerar funktioner.

Dock vore det mycket trevligt att ha själva pipe-funktionen som en instansmetod hos None och Just, men där gick jag bet. Har du någon ide hur det skulle kunna gå till?

Med vänlig hälsning,
/Björn